### PR TITLE
add: CockroachDB Serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Free tier of Heroku Dynos, Postgres and Data for Redis will no longer be availab
 
 [withcoherence.com](https://www.withcoherence.com/) - Coherence automates DevOps for early stage teams laser focused on customer value.
 
-[cockroachlabs.cloud](https://cockroachlabs.cloud/) - A next-generation PostgreSQL, with consumption-based, truly elastic scaling and pricing. Has a free tier and no credit card required for signing up.
+[cockroachlabs.cloud](https://cockroachlabs.cloud/) - CockroachDB Serverless is a next-generation PostgreSQL, with consumption-based, truly elastic scaling and pricing. It has a free tier and no credit card is needed for signing up.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,4 @@ Free tier of Heroku Dynos, Postgres and Data for Redis will no longer be availab
 
 [withcoherence.com](https://www.withcoherence.com/) - Coherence automates DevOps for early stage teams laser focused on customer value.
 
-[cockroachlabs.cloud](https://cockroachlabs.cloud/) - A next-generation PostgreSQL, with consumption-based, truly elastic scaling and pricing. Has a free tier and no credit card required.
-
-
+[cockroachlabs.cloud](https://cockroachlabs.cloud/) - A next-generation PostgreSQL, with consumption-based, truly elastic scaling and pricing. Has a free tier and no credit card required for signing up.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ Free tier of Heroku Dynos, Postgres and Data for Redis will no longer be availab
 
 [withcoherence.com](https://www.withcoherence.com/) - Coherence automates DevOps for early stage teams laser focused on customer value.
 
+[cockroachlabs.cloud](https://cockroachlabs.cloud/) - A next-generation PostgreSQL, with consumption-based, truly elastic scaling and pricing. Has a free tier and no credit card required.
+
 


### PR DESCRIPTION
This adds CockroachDB Serverless as an alternative which provides a free PostgreSQL compatible database as a service product. No credit card needed for signing up.
https://www.cockroachlabs.com/blog/how-we-built-cockroachdb-serverless/

Disclosure: I work at Cockroach Labs.